### PR TITLE
Add configurable "Animation Destination" support

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -8,62 +8,64 @@
 "use strict";
 
 var curveMapping = [
-                    // BASELINE
-                    QEasingCurve.Linear,
+    // BASELINE
+    QEasingCurve.Linear,
 
-                    // GENTLE (Sine)
-                    QEasingCurve.OutSine,
-                    QEasingCurve.InSine,
-                    QEasingCurve.InOutSine,
+    // GENTLE (Sine)
+    QEasingCurve.OutSine,
+    QEasingCurve.InSine,
+    QEasingCurve.InOutSine,
 
-                    // STANDARD (Quad, Cubic)
-                    QEasingCurve.OutQuad,
-                    QEasingCurve.InQuad,
-                    QEasingCurve.InOutQuad,
-                    QEasingCurve.OutCubic,
-                    QEasingCurve.InCubic,
-                    QEasingCurve.InOutCubic,
+    // STANDARD (Quad, Cubic)
+    QEasingCurve.OutQuad,
+    QEasingCurve.InQuad,
+    QEasingCurve.InOutQuad,
+    QEasingCurve.OutCubic,
+    QEasingCurve.InCubic,
+    QEasingCurve.InOutCubic,
 
-                    // SHARP (Quart, Quint, Expo)
-                    QEasingCurve.OutQuart,
-                    QEasingCurve.InQuart,
-                    QEasingCurve.InOutQuart,
-                    QEasingCurve.OutQuint,
-                    QEasingCurve.InQuint,
-                    QEasingCurve.InOutQuint,
-                    QEasingCurve.OutExpo,
-                    QEasingCurve.InExpo,
-                    QEasingCurve.InOutExpo,
+    // SHARP (Quart, Quint, Expo)
+    QEasingCurve.OutQuart,
+    QEasingCurve.InQuart,
+    QEasingCurve.InOutQuart,
+    QEasingCurve.OutQuint,
+    QEasingCurve.InQuint,
+    QEasingCurve.InOutQuint,
+    QEasingCurve.OutExpo,
+    QEasingCurve.InExpo,
+    QEasingCurve.InOutExpo,
 
-                    // SUDDEN (Circ)
-                    QEasingCurve.OutCirc,
-                    QEasingCurve.InCirc,
-                    QEasingCurve.InOutCirc,
+    // SUDDEN (Circ)
+    QEasingCurve.OutCirc,
+    QEasingCurve.InCirc,
+    QEasingCurve.InOutCirc,
 
-                    // PHYSICS (Back)
-                    QEasingCurve.OutBack,
-                    QEasingCurve.InBack,
-                    QEasingCurve.InOutBack,
+    // PHYSICS (Back)
+    QEasingCurve.OutBack,
+    QEasingCurve.InBack,
+    QEasingCurve.InOutBack,
 
-                    // PHYSICS (Elastic)
-                    QEasingCurve.OutElastic,
-                    QEasingCurve.InElastic,
-                    QEasingCurve.InOutElastic,
+    // PHYSICS (Elastic)
+    QEasingCurve.OutElastic,
+    QEasingCurve.InElastic,
+    QEasingCurve.InOutElastic,
 
-                    // PHYSICS (Bounce)
-                    QEasingCurve.OutBounce,
-                    QEasingCurve.InBounce,
-                    QEasingCurve.InOutBounce
-                    ];
+    // PHYSICS (Bounce)
+    QEasingCurve.OutBounce,
+    QEasingCurve.InBounce,
+    QEasingCurve.InOutBounce
+];
 
 var squashEffect = {
     duration: animationTime(250),
     opacity: 1.0,
     curveMin: QEasingCurve.OutExpo,
     curveUnmin: QEasingCurve.OutExpo,
+    minimizeTarget: 0, // 0=TaskManager, 1=TopLeft, 2=Top, 3=TopRight, 4=Left, 5=Right, 6=BottomLeft, 7=Bottom, 8=BottomRight, 9=Mouse
     loadConfig: function () {
         squashEffect.duration = animationTime(effect.readConfig("Duration", 250));
         squashEffect.opacity = effect.readConfig("Opacity", 100) / 100.0;
+        squashEffect.minimizeTarget = effect.readConfig("MinimizeTarget", 0);
 
         var minIndex = effect.readConfig("AnimationCurveMinimize", 16);
         if (minIndex < 0 || minIndex >= curveMapping.length) minIndex = 16;
@@ -73,17 +75,70 @@ var squashEffect = {
         if (unminIndex < 0 || unminIndex >= curveMapping.length) unminIndex = 16;
         squashEffect.curveUnmin = curveMapping[unminIndex];
     },
+    getTargetRect: function (window) {
+        var screenRect = workspace.clientArea(0, window);
+        var iconSize = 48; // Default icon size
+        var targetRect = { x: 0, y: 0, width: iconSize, height: iconSize };
+
+        switch (squashEffect.minimizeTarget) {
+            case 0: // Task Manager
+                var iconRect = window.iconGeometry;
+                if (iconRect.width > 0 && iconRect.height > 0) {
+                    return iconRect;
+                }
+                // Fallback to bottom if no icon geometry
+                targetRect.x = screenRect.x + (screenRect.width - iconSize) / 2;
+                targetRect.y = screenRect.y + screenRect.height - iconSize;
+                break;
+            case 1: // Top Left
+                targetRect.x = screenRect.x;
+                targetRect.y = screenRect.y;
+                break;
+            case 2: // Top
+                targetRect.x = screenRect.x + (screenRect.width - iconSize) / 2;
+                targetRect.y = screenRect.y;
+                break;
+            case 3: // Top Right
+                targetRect.x = screenRect.x + screenRect.width - iconSize;
+                targetRect.y = screenRect.y;
+                break;
+            case 4: // Left
+                targetRect.x = screenRect.x;
+                targetRect.y = screenRect.y + (screenRect.height - iconSize) / 2;
+                break;
+            case 5: // Right
+                targetRect.x = screenRect.x + screenRect.width - iconSize;
+                targetRect.y = screenRect.y + (screenRect.height - iconSize) / 2;
+                break;
+            case 6: // Bottom Left
+                targetRect.x = screenRect.x;
+                targetRect.y = screenRect.y + screenRect.height - iconSize;
+                break;
+            case 7: // Bottom
+                targetRect.x = screenRect.x + (screenRect.width - iconSize) / 2;
+                targetRect.y = screenRect.y + screenRect.height - iconSize;
+                break;
+            case 8: // Bottom Right
+                targetRect.x = screenRect.x + screenRect.width - iconSize;
+                targetRect.y = screenRect.y + screenRect.height - iconSize;
+                break;
+            case 9: // Mouse
+                var cursorPos = effects.cursorPos;
+                targetRect.x = cursorPos.x - iconSize / 2;
+                targetRect.y = cursorPos.y - iconSize / 2;
+                break;
+        }
+
+        return targetRect;
+    },
     slotWindowMinimized: function (window) {
+        console.log("SquashPlus: Window minimized event triggered for", window.caption);
         if (effects.hasActiveFullScreenEffect) {
             return;
         }
 
-        // If the window doesn't have an icon in the task manager,
-        // don't animate it.
-        var iconRect = window.iconGeometry;
-        if (iconRect.width == 0 || iconRect.height == 0) {
-            return;
-        }
+        // Get the target rectangle based on minimize target setting
+        var iconRect = squashEffect.getTargetRect(window);
 
         if (window.unminimizeAnimation) {
             if (redirect(window.unminimizeAnimation, Effect.Backward)) {
@@ -140,16 +195,13 @@ var squashEffect = {
         });
     },
     slotWindowUnminimized: function (window) {
+        console.log("SquashPlus: Window unminimized event triggered for", window.caption);
         if (effects.hasActiveFullScreenEffect) {
             return;
         }
 
-        // If the window doesn't have an icon in the task manager,
-        // don't animate it.
-        var iconRect = window.iconGeometry;
-        if (iconRect.width == 0 || iconRect.height == 0) {
-            return;
-        }
+        // Get the target rectangle based on minimize target setting
+        var iconRect = squashEffect.getTargetRect(window);
 
         if (window.minimizeAnimation) {
             if (redirect(window.minimizeAnimation, Effect.Backward)) {

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -66,6 +66,9 @@ var squashEffect = {
         squashEffect.duration = animationTime(effect.readConfig("Duration", 250));
         squashEffect.opacity = effect.readConfig("Opacity", 100) / 100.0;
         squashEffect.minimizeTarget = effect.readConfig("MinimizeTarget", 0);
+        if (squashEffect.minimizeTarget < 0 || squashEffect.minimizeTarget > 9) {
+            squashEffect.minimizeTarget = 0;
+        }
 
         var minIndex = effect.readConfig("AnimationCurveMinimize", 16);
         if (minIndex < 0 || minIndex >= curveMapping.length) minIndex = 16;
@@ -75,8 +78,30 @@ var squashEffect = {
         if (unminIndex < 0 || unminIndex >= curveMapping.length) unminIndex = 16;
         squashEffect.curveUnmin = curveMapping[unminIndex];
     },
+    getScreenRect: function (window) {
+        // KWin effects scripts don't provide `workspace`.
+        // Try per-window output geometry first, then virtual display bounds.
+        if (window && window.output && window.output.geometry) {
+            return window.output.geometry;
+        }
+
+        if (window && window.screenGeometry) {
+            return window.screenGeometry;
+        }
+
+        if (effects.virtualScreenGeometry) {
+            return effects.virtualScreenGeometry;
+        }
+
+        return {
+            x: 0,
+            y: 0,
+            width: effects.displayWidth,
+            height: effects.displayHeight
+        };
+    },
     getTargetRect: function (window) {
-        var screenRect = workspace.clientArea(0, window);
+        var screenRect = squashEffect.getScreenRect(window);
         var iconSize = 48; // Default icon size
         var targetRect = { x: 0, y: 0, width: iconSize, height: iconSize };
 
@@ -132,7 +157,6 @@ var squashEffect = {
         return targetRect;
     },
     slotWindowMinimized: function (window) {
-        console.log("SquashPlus: Window minimized event triggered for", window.caption);
         if (effects.hasActiveFullScreenEffect) {
             return;
         }
@@ -195,7 +219,6 @@ var squashEffect = {
         });
     },
     slotWindowUnminimized: function (window) {
-        console.log("SquashPlus: Window unminimized event triggered for", window.caption);
         if (effects.hasActiveFullScreenEffect) {
             return;
         }

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -67,8 +67,7 @@ var squashEffect = {
         squashEffect.opacity = effect.readConfig("Opacity", 100) / 100.0;
         var minimizeTargetValue = effect.readConfig("MinimizeTarget", 0);
 
-        // Depending on runtime/config migration path, enum values may come back
-        // either as index or as string name. Normalize to index.
+        // Normalize enum values to index.
         if (typeof minimizeTargetValue === "string") {
             var minimizeTargetMap = {
                 TaskManager: 0,
@@ -101,8 +100,6 @@ var squashEffect = {
         squashEffect.curveUnmin = curveMapping[unminIndex];
     },
     getScreenRect: function (window) {
-        // KWin effects scripts don't provide `workspace`.
-        // Try per-window output geometry first, then virtual display bounds.
         if (window && window.output && window.output.geometry) {
             return window.output.geometry;
         }

--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -65,7 +65,29 @@ var squashEffect = {
     loadConfig: function () {
         squashEffect.duration = animationTime(effect.readConfig("Duration", 250));
         squashEffect.opacity = effect.readConfig("Opacity", 100) / 100.0;
-        squashEffect.minimizeTarget = effect.readConfig("MinimizeTarget", 0);
+        var minimizeTargetValue = effect.readConfig("MinimizeTarget", 0);
+
+        // Depending on runtime/config migration path, enum values may come back
+        // either as index or as string name. Normalize to index.
+        if (typeof minimizeTargetValue === "string") {
+            var minimizeTargetMap = {
+                TaskManager: 0,
+                TopLeft: 1,
+                Top: 2,
+                TopRight: 3,
+                Left: 4,
+                Right: 5,
+                BottomLeft: 6,
+                Bottom: 7,
+                BottomRight: 8,
+                Mouse: 9
+            };
+            if (Object.prototype.hasOwnProperty.call(minimizeTargetMap, minimizeTargetValue)) {
+                minimizeTargetValue = minimizeTargetMap[minimizeTargetValue];
+            }
+        }
+
+        squashEffect.minimizeTarget = Number(minimizeTargetValue);
         if (squashEffect.minimizeTarget < 0 || squashEffect.minimizeTarget > 9) {
             squashEffect.minimizeTarget = 0;
         }
@@ -288,6 +310,8 @@ var squashEffect = {
         });
     },
     init: function () {
+        // Ensure saved settings are loaded on startup.
+        squashEffect.loadConfig();
         effect.configChanged.connect(squashEffect.loadConfig);
 
         effects.windowAdded.connect(squashEffect.slotWindowAdded);

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -13,6 +13,42 @@
             <default>100</default>
             <label>Final opacity of the window when minimized (percentage)</label>
         </entry>
+        <entry name="MinimizeTarget" type="Enum">
+            <label>Where the window minimizes to</label>
+            <default>TaskManager</default>
+            <choices>
+                <choice name="TaskManager">
+                    <label>Task Manager (Default)</label>
+                </choice>
+                <choice name="TopLeft">
+                    <label>Fixed - Top Left</label>
+                </choice>
+                <choice name="Top">
+                    <label>Fixed - Top</label>
+                </choice>
+                <choice name="TopRight">
+                    <label>Fixed - Top Right</label>
+                </choice>
+                <choice name="Left">
+                    <label>Fixed - Left</label>
+                </choice>
+                <choice name="Right">
+                    <label>Fixed - Right</label>
+                </choice>
+                <choice name="BottomLeft">
+                    <label>Fixed - Bottom Left</label>
+                </choice>
+                <choice name="Bottom">
+                    <label>Fixed - Bottom</label>
+                </choice>
+                <choice name="BottomRight">
+                    <label>Fixed - Bottom Right</label>
+                </choice>
+                <choice name="Mouse">
+                    <label>Mouse Position</label>
+                </choice>
+            </choices>
+        </entry>
         <entry name="AnimationCurveMinimize" type="Enum">
             <label>The animation curve to use</label>
             <default>OutExpo</default>

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -52,13 +52,35 @@
             </item>
 
             <item row="2" column="0">
+                <widget class="QLabel" name="label_MinimizeTarget">
+                    <property name="text">
+                        <string>Minimize To:</string>
+                    </property>
+                </widget>
+            </item>
+            <item row="2" column="1">
+                <widget class="QComboBox" name="kcfg_MinimizeTarget">
+                    <item><property name="text"><string>Task Manager (Default)</string></property></item>
+                    <item><property name="text"><string>Fixed - Top Left</string></property></item>
+                    <item><property name="text"><string>Fixed - Top</string></property></item>
+                    <item><property name="text"><string>Fixed - Top Right</string></property></item>
+                    <item><property name="text"><string>Fixed - Left</string></property></item>
+                    <item><property name="text"><string>Fixed - Right</string></property></item>
+                    <item><property name="text"><string>Fixed - Bottom Left</string></property></item>
+                    <item><property name="text"><string>Fixed - Bottom</string></property></item>
+                    <item><property name="text"><string>Fixed - Bottom Right</string></property></item>
+                    <item><property name="text"><string>Mouse Position</string></property></item>
+                </widget>
+            </item>
+
+            <item row="3" column="0">
                 <widget class="QLabel" name="label_CurveMin">
                     <property name="text">
                         <string>Minimize Curve:</string>
                     </property>
                 </widget>
             </item>
-            <item row="2" column="1">
+            <item row="3" column="1">
                 <widget class="QComboBox" name="kcfg_AnimationCurveMinimize">
                     <item><property name="text"><string>Linear (No Acceleration)</string></property></item>
 
@@ -101,14 +123,14 @@
                 </widget>
             </item>
 
-            <item row="3" column="0">
+            <item row="4" column="0">
                 <widget class="QLabel" name="label_CurveUnmin">
                     <property name="text">
                         <string>Unminimize Curve:</string>
                     </property>
                 </widget>
             </item>
-            <item row="3" column="1">
+            <item row="4" column="1">
                 <widget class="QComboBox" name="kcfg_AnimationCurveUnminimize">
                     <item><property name="text"><string>Linear (No Acceleration)</string></property></item>
 

--- a/metadata.json
+++ b/metadata.json
@@ -46,15 +46,15 @@
             {
                 "Name": "Shaurya Kalia",
                 "Email": ""
-        }
+            }
         ],
         "Category": "Appearance",
         "EnabledByDefault": false,
         "Icon": "preferences-system-windows-effect-squash",
         "License": "GPL-3.0"
-},
+    },
     "X-KDE-ConfigModule": "kcm_kwin4_genericscripted",
     "X-Plasma-MainScript": "code/main.js",
     "X-KDE-Ordering": 60,
     "X-Plasma-API": "javascript"
-    }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -48,6 +48,12 @@
                 "Email": ""
             }
         ],
+        "OtherContributors": [
+            {
+                "Name": "Ray Zhang",
+                "Email": "rayzhangshanghai@hotmail.com"
+            }
+        ],
         "Category": "Appearance",
         "EnabledByDefault": false,
         "Icon": "preferences-system-windows-effect-squash",


### PR DESCRIPTION
Currently the squash animation drops windows to the task manager and is not configurable. This pull request adds a configuration that allows users to choose between minimizing to the task manager, a fixed place (like "top left corner"), or the mouse.